### PR TITLE
Remove trailing comma to fix subject line.

### DIFF
--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -106,7 +106,7 @@ def send_templated_mail(template_name,
     subject_part = from_string(
         HELPDESK_EMAIL_SUBJECT_TEMPLATE % {
             "subject": t.subject
-        }).render(context).replace('\r', ' ').replace('\n', ' '),
+        }).render(context).replace('\r', ' ').replace('\n', ' ')
 
     if isinstance(recipients, str):
         if recipients.find(','):


### PR DESCRIPTION
The comma resulted in subject lines looking like this:

 (u'Testing helpdesk with attachments (Updated) [ep2017-20415]',)